### PR TITLE
Use ReadFull to read a specific number of bytes

### DIFF
--- a/field.go
+++ b/field.go
@@ -34,7 +34,7 @@ func (cf *ControlField) GetTag() string {
 
 func readControl(reader io.Reader, dent *dirent) (field Field, err error) {
 	data := make([]byte, dent.length)
-	n, err := reader.Read(data)
+	n, err := io.ReadFull(reader, data)
 	if err != nil {
 		return
 	}
@@ -121,7 +121,7 @@ func (df *DataField) String() string {
 
 func readData(reader io.Reader, dent *dirent) (field Field, err error) {
 	data := make([]byte, dent.length)
-	n, err := reader.Read(data)
+	n, err := io.ReadFull(reader, data)
 	if err != nil {
 		return
 	}

--- a/marc21.go
+++ b/marc21.go
@@ -68,7 +68,7 @@ func ParseLeader(r io.Reader) (leader *Leader, err error) {
 
 func readLeader(reader io.Reader) (leader *Leader, err error) {
 	data := make([]byte, 24)
-	n, err := reader.Read(data)
+	n, err := io.ReadFull(reader, data)
 	if err != nil {
 		return
 	}
@@ -137,7 +137,7 @@ func readDirEnt(reader io.Reader) (dent *dirent, err error) {
 		err = ErrFieldSeparator
 		return
 	}
-	n, err := reader.Read(data[1:])
+	n, err := io.ReadFull(reader, data[1:])
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The Read method on an io.Reader is guaranteed to only read up to the
specified number of bytes. It can legitimately read less than that.
ReadFull will read exactly the specified number of bytes.